### PR TITLE
Have TestsuiteExecutor read environment variables directly, so users …

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 # TBD
+### Features
+* The `TestsuiteExecutor` no longer requires a constructor with Kurtosis API socket, loglevel, and testsuite params args, and instead reads them directly from the environment
+
 ### Fixes
 * Remove the docs for the now-nonexistent `Test.getSetupTimeout` and `Test.getRunTimeout` methods
+
+### Breaking Changes
+* `NewTestsuiteExecutor` no longer reads Kurtosis API socket, loglevel, or serialized testsuite params
+    * This means that users can change their Dockerfile `CMD` to simply call their program, with no need to read any environment variables - e.g. `CMD ./testsuite.bin --api-socket ${API_SOCKET} --log-level ${LOG_LEVEL} --custom-params ${CUSTOM_PARAMS}` becomes `CMD ./testsuite.bin`
 
 # 0.1.2
 ### Changes

--- a/golang/kurtosis_testsuite_docker_api/kurtosis_testsuite_docker_api.go
+++ b/golang/kurtosis_testsuite_docker_api/kurtosis_testsuite_docker_api.go
@@ -1,6 +1,7 @@
 package kurtosis_testsuite_docker_api
 
 const (
+	// TODO Rename this envvar, since the testsuite can accept whatever it wants - doesn't have to be JSON
 	CustomParamsJsonEnvVar  = "CUSTOM_PARAMS_JSON"
 	DebuggerPortEnvVar      = "DEBUGGER_PORT"
 	KurtosisApiSocketEnvVar = "KURTOSIS_API_SOCKET" // Only populated if in test-running mode

--- a/golang/lib/execution/test_suite_executor.go
+++ b/golang/lib/execution/test_suite_executor.go
@@ -2,11 +2,13 @@ package execution
 
 import (
 	"github.com/kurtosis-tech/kurtosis-client/golang/kurtosis_core_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis-testsuite-api-lib/golang/kurtosis_testsuite_docker_api"
 	"github.com/kurtosis-tech/kurtosis-testsuite-api-lib/golang/kurtosis_testsuite_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis-testsuite-api-lib/golang/kurtosis_testsuite_rpc_api_consts"
 	"github.com/kurtosis-tech/minimal-grpc-server/server"
 	"github.com/palantir/stacktrace"
 	"google.golang.org/grpc"
+	"os"
 	"time"
 )
 
@@ -15,35 +17,51 @@ const (
 )
 
 type TestSuiteExecutor struct {
-	kurtosisApiSocket string  // Can be empty if the testsuite is in metadata-providing mode
-	logLevelStr string
-	paramsJsonStr string
 	configurator TestSuiteConfigurator
 }
 
-func NewTestSuiteExecutor(kurtosisApiSocket string, logLevelStr string, paramsJsonStr string, configurator TestSuiteConfigurator) *TestSuiteExecutor {
-	return &TestSuiteExecutor{kurtosisApiSocket: kurtosisApiSocket, logLevelStr: logLevelStr, paramsJsonStr: paramsJsonStr, configurator: configurator}
+func NewTestSuiteExecutor(configurator TestSuiteConfigurator) *TestSuiteExecutor {
+	return &TestSuiteExecutor{configurator: configurator}
 }
 
 func (executor TestSuiteExecutor) Run() error {
-	if err := executor.configurator.SetLogLevel(executor.logLevelStr); err != nil {
+	// NOTE: This can be empty if the testsuite is in metadata-providing mode
+	kurtosisApiSocketStr := os.Getenv(kurtosis_testsuite_docker_api.KurtosisApiSocketEnvVar)
+
+	logLevelStr, found := os.LookupEnv(kurtosis_testsuite_docker_api.LogLevelEnvVar)
+	if !found {
+		return stacktrace.NewError("Expected an '%v' environment variable containing the log level string that the testsuite should log at, but none was found", kurtosis_testsuite_docker_api.LogLevelEnvVar)
+	}
+	if logLevelStr == "" {
+		return stacktrace.NewError("The '%v' loglevel environment variable was defined, but is emptystring", kurtosis_testsuite_docker_api.LogLevelEnvVar)
+	}
+
+	customSerializedParamsStr, found := os.LookupEnv(kurtosis_testsuite_docker_api.CustomParamsJsonEnvVar)
+	if !found {
+		return stacktrace.NewError("Expected an '%v' environment variable containing the serialized custom params that the testsuite will consume, but none was found", kurtosis_testsuite_docker_api.CustomParamsJsonEnvVar)
+	}
+	if customSerializedParamsStr == "" {
+		return stacktrace.NewError("The '%v' serialized custom params environment variable was defined, but is emptystring", kurtosis_testsuite_docker_api.CustomParamsJsonEnvVar)
+	}
+
+	if err := executor.configurator.SetLogLevel(logLevelStr); err != nil {
 		return stacktrace.Propagate(err, "An error occurred setting the loglevel before running the testsuite")
 	}
 
-	suite, err := executor.configurator.ParseParamsAndCreateSuite(executor.paramsJsonStr)
+	suite, err := executor.configurator.ParseParamsAndCreateSuite(customSerializedParamsStr)
 	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred parsing the suite params JSON and creating the testsuite")
+		return stacktrace.Propagate(err, "An error occurred parsing the serialized testsuite params and creating the testsuite")
 	}
 
 	var apiContainerService kurtosis_core_rpc_api_bindings.ApiContainerServiceClient = nil
-	if executor.kurtosisApiSocket != "" {
+	if kurtosisApiSocketStr != "" {
 		// TODO SECURITY: Use HTTPS to ensure we're connecting to the real Kurtosis API servers
-		conn, err := grpc.Dial(executor.kurtosisApiSocket, grpc.WithInsecure())
+		conn, err := grpc.Dial(kurtosisApiSocketStr, grpc.WithInsecure())
 		if err != nil {
 			return stacktrace.Propagate(
 				err,
 				"An error occurred creating a connection to the Kurtosis API server at '%v'",
-				executor.kurtosisApiSocket,
+				kurtosisApiSocketStr,
 			)
 		}
 		defer conn.Close()


### PR DESCRIPTION
…don't need to know or care what variables are consumed by Kurtosis

WHY THIS IS AWESOME: https://github.com/kurtosis-tech/kurtosis-core/pull/282

- It means the user doesn't need to know anything about the environment variables that a) the API container is setting or b) the testsuite container is consuming. 
- In the current world, if we add a new environment variable, ALL users need to update their Dockerfiles to accept it.
- In this new world, we can transparently change the API without the user noticing

Extra reason this is awesome: the environment variable names are entirely determined by the `kurtosis_testsuite_docker_api` consts (whereas before, we had those same names duplicated in the Dockerfile)